### PR TITLE
feat: Connect dashboard to API and add tests

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 import { serverSideTranslations } from 'next-i18next';
 import { useTranslation } from 'next-i18next';
 import { GetServerSideProps } from 'next';
@@ -20,18 +21,44 @@ import DashboardLayout from '../components/layouts/DashboardLayout';
 export default function Dashboard() {
   const { t } = useTranslation('common');
   const theme = useTheme();
-  
-  // Mock data for dashboard
-  const [properties, setProperties] = useState([
-    { id: 'PROP_001', name: 'Downtown Apartment', developer: 'Emaar', price: 1250000, yield: 6.8 },
-    { id: 'PROP_002', name: 'Marina Penthouse', developer: 'Damac', price: 3500000, yield: 5.9 },
-    { id: 'PROP_003', name: 'Palm Villa', developer: 'Nakheel', price: 7800000, yield: 4.7 },
-  ]);
-  
-  const [proposals, setProposals] = useState([
-    { id: 'prop_123abc', date: '2025-05-15', properties: 2, status: 'completed' },
-    { id: 'prop_456def', date: '2025-05-10', properties: 1, status: 'completed' },
-  ]);
+
+  const [properties, setProperties] = useState<any[]>([]);
+  const [proposals, setProposals] = useState<any[]>([]);
+  const [propertiesLoading, setPropertiesLoading] = useState(true);
+  const [proposalsLoading, setProposalsLoading] = useState(true);
+  const [propertiesError, setPropertiesError] = useState<string | null>(null);
+  const [proposalsError, setProposalsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProperties = async () => {
+      setPropertiesLoading(true);
+      setPropertiesError(null);
+      try {
+        const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/properties/`);
+        setProperties(response.data);
+        setPropertiesLoading(false);
+      } catch (error) {
+        setPropertiesError('Failed to fetch properties');
+        setPropertiesLoading(false);
+      }
+    };
+
+    const fetchProposals = async () => {
+      setProposalsLoading(true);
+      setProposalsError(null);
+      try {
+        const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/proposals/`);
+        setProposals(response.data);
+        setProposalsLoading(false);
+      } catch (error) {
+        setProposalsError('Failed to fetch proposals');
+        setProposalsLoading(false);
+      }
+    };
+
+    fetchProperties();
+    fetchProposals();
+  }, []);
 
   return (
     <DashboardLayout>
@@ -42,37 +69,58 @@ export default function Dashboard() {
         
         <Grid container spacing={3}>
           {/* Summary Cards */}
+          {/* Summary Cards */}
           <Grid item xs={12} md={4}>
             <Card>
               <CardHeader title={t('dashboard.properties')} />
               <CardContent>
-                <Typography variant="h3">{properties.length}</Typography>
+                {propertiesLoading ? (
+                  <Typography>{t('dashboard.loading')}</Typography>
+                ) : propertiesError ? (
+                  <Typography color="error">{propertiesError}</Typography>
+                ) : (
+                  <Typography variant="h3">{properties.length}</Typography>
+                )}
                 <Typography variant="body2" color="text.secondary">
                   {t('dashboard.availableProperties')}
                 </Typography>
               </CardContent>
             </Card>
           </Grid>
-          
+
           <Grid item xs={12} md={4}>
             <Card>
               <CardHeader title={t('dashboard.proposals')} />
               <CardContent>
-                <Typography variant="h3">{proposals.length}</Typography>
+                {proposalsLoading ? (
+                  <Typography>{t('dashboard.loading')}</Typography>
+                ) : proposalsError ? (
+                  <Typography color="error">{proposalsError}</Typography>
+                ) : (
+                  <Typography variant="h3">{proposals.length}</Typography>
+                )}
                 <Typography variant="body2" color="text.secondary">
                   {t('dashboard.generatedProposals')}
                 </Typography>
               </CardContent>
             </Card>
           </Grid>
-          
+
           <Grid item xs={12} md={4}>
             <Card>
               <CardHeader title={t('dashboard.averageYield')} />
               <CardContent>
-                <Typography variant="h3">
-                  {(properties.reduce((acc, prop) => acc + prop.yield, 0) / properties.length).toFixed(1)}%
-                </Typography>
+                {propertiesLoading ? (
+                  <Typography>{t('dashboard.loading')}</Typography>
+                ) : propertiesError ? (
+                  <Typography color="error">{propertiesError}</Typography>
+                ) : properties.length > 0 ? (
+                  <Typography variant="h3">
+                    {(properties.reduce((acc, prop) => acc + prop.yield, 0) / properties.length).toFixed(1)}%
+                  </Typography>
+                ) : (
+                  <Typography variant="h3">N/A</Typography>
+                )}
                 <Typography variant="body2" color="text.secondary">
                   {t('dashboard.acrossAllProperties')}
                 </Typography>
@@ -87,37 +135,44 @@ export default function Dashboard() {
                 {t('dashboard.recentProperties')}
               </Typography>
               <Divider sx={{ mb: 2 }} />
-              
-              <Grid container spacing={2}>
-                {properties.map((property) => (
-                  <Grid item xs={12} md={4} key={property.id}>
-                    <Card>
-                      <CardContent>
-                        <Typography variant="h6">{property.name}</Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          {property.developer}
-                        </Typography>
-                        <Typography variant="body1" sx={{ mt: 2 }}>
-                          AED {property.price.toLocaleString()}
-                        </Typography>
-                        <Typography variant="body2" color="primary">
-                          {property.yield}% {t('dashboard.yield')}
-                        </Typography>
-                        <Button 
-                          variant="contained" 
-                          size="small" 
-                          sx={{ mt: 2 }}
-                        >
-                          {t('dashboard.generateProposal')}
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                ))}
-              </Grid>
+              {propertiesLoading ? (
+                <Typography>{t('dashboard.loadingProperties')}</Typography>
+              ) : propertiesError ? (
+                <Typography color="error">{propertiesError}</Typography>
+              ) : properties.length > 0 ? (
+                <Grid container spacing={2}>
+                  {properties.map((property) => (
+                    <Grid item xs={12} md={4} key={property.id}>
+                      <Card>
+                        <CardContent>
+                          <Typography variant="h6">{property.name}</Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {property.developer}
+                          </Typography>
+                          <Typography variant="body1" sx={{ mt: 2 }}>
+                            AED {property.price.toLocaleString()}
+                          </Typography>
+                          <Typography variant="body2" color="primary">
+                            {property.yield}% {t('dashboard.yield')}
+                          </Typography>
+                          <Button
+                            variant="contained"
+                            size="small"
+                            sx={{ mt: 2 }}
+                          >
+                            {t('dashboard.generateProposal')}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    </Grid>
+                  ))}
+                </Grid>
+              ) : (
+                <Typography>{t('dashboard.noPropertiesFound')}</Typography>
+              )}
             </Paper>
           </Grid>
-          
+
           {/* Recent Proposals */}
           <Grid item xs={12}>
             <Paper sx={{ p: 2 }}>
@@ -125,43 +180,50 @@ export default function Dashboard() {
                 {t('dashboard.recentProposals')}
               </Typography>
               <Divider sx={{ mb: 2 }} />
-              
-              <Grid container spacing={2}>
-                {proposals.map((proposal) => (
-                  <Grid item xs={12} md={6} key={proposal.id}>
-                    <Card>
-                      <CardContent>
-                        <Typography variant="h6">
-                          {t('dashboard.proposalId')}: {proposal.id}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          {t('dashboard.generated')}: {proposal.date}
-                        </Typography>
-                        <Typography variant="body2" sx={{ mt: 1 }}>
-                          {t('dashboard.properties')}: {proposal.properties}
-                        </Typography>
-                        <Typography variant="body2" color="primary">
-                          {t('dashboard.status')}: {proposal.status}
-                        </Typography>
-                        <Button 
-                          variant="outlined" 
-                          size="small" 
-                          sx={{ mt: 2, mr: 1 }}
-                        >
-                          {t('dashboard.viewPdf')}
-                        </Button>
-                        <Button 
-                          variant="outlined" 
-                          size="small" 
-                          sx={{ mt: 2 }}
-                        >
-                          {t('dashboard.share')}
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                ))}
-              </Grid>
+              {proposalsLoading ? (
+                <Typography>{t('dashboard.loadingProposals')}</Typography>
+              ) : proposalsError ? (
+                <Typography color="error">{proposalsError}</Typography>
+              ) : proposals.length > 0 ? (
+                <Grid container spacing={2}>
+                  {proposals.map((proposal) => (
+                    <Grid item xs={12} md={6} key={proposal.id}>
+                      <Card>
+                        <CardContent>
+                          <Typography variant="h6">
+                            {t('dashboard.proposalId')}: {proposal.id}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {t('dashboard.generated')}: {proposal.date}
+                          </Typography>
+                          <Typography variant="body2" sx={{ mt: 1 }}>
+                            {t('dashboard.properties')}: {proposal.properties}
+                          </Typography>
+                          <Typography variant="body2" color="primary">
+                            {t('dashboard.status')}: {proposal.status}
+                          </Typography>
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            sx={{ mt: 2, mr: 1 }}
+                          >
+                            {t('dashboard.viewPdf')}
+                          </Button>
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            sx={{ mt: 2 }}
+                          >
+                            {t('dashboard.share')}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    </Grid>
+                  ))}
+                </Grid>
+              ) : (
+                <Typography>{t('dashboard.noProposalsFound')}</Typography>
+              )}
             </Paper>
           </Grid>
         </Grid>

--- a/frontend/tests/pages/index.test.tsx
+++ b/frontend/tests/pages/index.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import Dashboard from '../../pages/index'; // Adjust path as necessary
+import '@testing-library/jest-dom';
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock next-i18next
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  serverSideTranslations: jest.fn().mockResolvedValue({}),
+}));
+
+// Mock next/router (optional, enable if needed)
+// jest.mock('next/router', () => ({
+//   useRouter: () => ({
+//     route: '/',
+//     pathname: '',
+//     query: '',
+//     asPath: '',
+//     push: jest.fn(),
+//     events: {
+//       on: jest.fn(),
+//       off: jest.fn(),
+//     },
+//     beforePopState: jest.fn(() => null),
+//     prefetch: jest.fn(() => null),
+//   }),
+// }));
+
+// Set up NEXT_PUBLIC_API_URL
+process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000/api';
+
+describe('Dashboard Page', () => {
+  beforeEach(() => {
+    // Clear all previous mock calls and implementations
+    mockedAxios.get.mockReset();
+  });
+
+  test('renders loading states initially', () => {
+    render(<Dashboard />);
+    expect(screen.getByText('dashboard.loadingProperties')).toBeInTheDocument();
+    expect(screen.getByText('dashboard.loadingProposals')).toBeInTheDocument();
+  });
+
+  test('fetches and displays properties and proposals successfully', async () => {
+    const mockProperties = [{ id: 'PROP_001', name: 'Test Property', developer: 'Test Dev', price: 100000, yield: 5.0, currency: 'AED' }];
+    const mockProposals = [{ id: 'prop_test1', date: '2023-01-01', properties_count: 1, status: 'completed' }];
+
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.includes('/properties')) {
+        return Promise.resolve({ data: mockProperties });
+      }
+      if (url.includes('/proposals')) {
+        return Promise.resolve({ data: mockProposals });
+      }
+      return Promise.reject(new Error('not found'));
+    });
+    
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Property')).toBeInTheDocument();
+      expect(screen.getByText((content, element) => content.startsWith('dashboard.proposalId') && content.includes('prop_test1'))).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('dashboard.loadingProperties')).not.toBeInTheDocument();
+    expect(screen.queryByText('dashboard.loadingProposals')).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument(); // Properties count
+    expect(screen.getByText('1')).toBeInTheDocument(); // Proposals count
+  });
+
+  test('displays error message if properties fetch fails', async () => {
+    const mockProposals = [{ id: 'prop_test1', date: '2023-01-01', properties_count: 1, status: 'completed' }];
+    
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.includes('/properties')) {
+        return Promise.reject(new Error('Failed to fetch properties'));
+      }
+      if (url.includes('/proposals')) {
+        return Promise.resolve({ data: mockProposals });
+      }
+      return Promise.reject(new Error('not found'));
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch properties')).toBeInTheDocument();
+    });
+    
+    // Check that proposals are still loaded or loading
+    await waitFor(() => {
+        expect(screen.getByText((content, element) => content.startsWith('dashboard.proposalId') && content.includes('prop_test1'))).toBeInTheDocument();
+    });
+    expect(screen.queryByText('dashboard.loadingProposals')).not.toBeInTheDocument();
+  });
+
+  test('displays error message if proposals fetch fails', async () => {
+    const mockProperties = [{ id: 'PROP_001', name: 'Test Property', developer: 'Test Dev', price: 100000, yield: 5.0, currency: 'AED' }];
+
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.includes('/properties')) {
+        return Promise.resolve({ data: mockProperties });
+      }
+      if (url.includes('/proposals')) {
+        return Promise.reject(new Error('Failed to fetch proposals'));
+      }
+      return Promise.reject(new Error('not found'));
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch proposals')).toBeInTheDocument();
+    });
+
+    // Check that properties are still loaded
+    await waitFor(() => {
+      expect(screen.getByText('Test Property')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('dashboard.loadingProperties')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Makes the frontend dashboard (pages/index.tsx) fetch and display real data for properties and proposals from the backend API, replacing the previous mock data.

Key changes:
- Modified frontend/pages/index.tsx:
  - Implemented useEffect hook to fetch data from /properties/ and /proposals/ endpoints using axios.
  - Added state management for loading and error handling during data fetching.
  - Updated JSX to render loading indicators, error messages, or fetched data.
  - Assumes backend API will provide NEXT_PUBLIC_API_URL for the base API path.
- Added frontend/tests/pages/index.test.tsx:
  - Basic Jest/React Testing Library tests for the dashboard page.
  - Tests cover initial loading states, successful data display, and error handling for API calls.
  - Mocks axios for API call simulation.

This change addresses the issue of the dashboard not displaying live data. Further work will be needed to implement the required backend endpoints (/properties/ and /proposals/) and to make the action buttons on the dashboard functional.